### PR TITLE
Issue 6

### DIFF
--- a/RemoteImageView/RemoteImageView.m
+++ b/RemoteImageView/RemoteImageView.m
@@ -58,6 +58,7 @@
 static UIImage *_globalDefaultImage;
 static NSMutableArray *_imageLoadingQueue;
 static NSCache *_imageCache;
+static NSLock *_loadingQueueLock;
 
 @implementation RemoteImageView
 
@@ -79,6 +80,9 @@ NSURLSessionDataTask *dataTask = NULL;
     _imageLoadingQueue = [[NSMutableArray alloc] init];
     _imageCache = [[NSCache alloc] init];
     _imageCache.name = @"RemoteImageView_imageCache";
+    _loadingQueueLock = [[NSLock alloc] init];
+    _loadingQueueLock.name = @"LoadingQueueLock";
+    
 }
 
 - (id)init {

--- a/RemoteImageView/RemoteImageView.m
+++ b/RemoteImageView/RemoteImageView.m
@@ -170,7 +170,9 @@ NSURLSessionDataTask *dataTask = NULL;
         return;
     }
     
+    [_loadingQueueLock lock];
     [_imageLoadingQueue addObject:self];
+    [_loadingQueueLock unlock];
     
     NSURLRequest *request = [NSURLRequest requestWithURL:imageURL
                                              cachePolicy:_cacheMode != RIDiskCacheMode ? NSURLRequestReloadIgnoringCacheData :
@@ -335,8 +337,13 @@ NSURLSessionDataTask *dataTask = NULL;
 
 - (void)cacheImage:(UIImage *)image forURL:(NSURL *)url {
     
+    if (image == nil) {
+        return;
+    }
+    
     CGSize imageSize = _resizeImage ? CGSizeMake(self.frame.size.width, self.frame.size.height) : CGSizeZero;
-    if(image) [_imageCache setObject:image forKey:[RemoteImageView pathForURL:url size:imageSize]];
+    
+    [_imageCache setObject:image forKey:[RemoteImageView pathForURL:url size:imageSize]];
     
     if(_cacheMode == RIDiskCacheMode) {
         NSString *imagePath = [RemoteImageView pathForURL:url size:imageSize];
@@ -457,10 +464,12 @@ NSURLSessionDataTask *dataTask = NULL;
 #pragma mark cancelAll
 
 + (void)cancelAll {
+    [_loadingQueueLock lock];
     for (RemoteImageView* aView in _imageLoadingQueue) {
         [aView cancelAndRemove:NO];
     }
     [_imageLoadingQueue removeAllObjects];
+    [_loadingQueueLock unlock];
 }
 
 @end

--- a/RemoteImageView/RemoteImageView.m
+++ b/RemoteImageView/RemoteImageView.m
@@ -211,11 +211,21 @@ NSURLSessionDataTask *dataTask = NULL;
 }
 
 - (void)cancel {
+    [self cancelAndRemove:YES];
+}
+
+- (void)cancelAndRemove:(BOOL) shouldRemove {
     if (dataTask != NULL) {
         [dataTask cancel];
-        NSUInteger index = [_imageLoadingQueue indexOfObject:self];
-        if (index != NSNotFound) {
-            [_imageLoadingQueue removeObjectAtIndex:index];
+        if (shouldRemove == YES) {
+            [_loadingQueueLock lock];
+            NSUInteger index = [_imageLoadingQueue indexOfObject:self];
+            [_loadingQueueLock unlock];
+            if (index != NSNotFound) {
+                [_loadingQueueLock lock];
+                [_imageLoadingQueue removeObjectAtIndex:index];
+                [_loadingQueueLock unlock];
+            }
         }
     }
 }
@@ -444,8 +454,9 @@ NSURLSessionDataTask *dataTask = NULL;
 
 + (void)cancelAll {
     for (RemoteImageView* aView in _imageLoadingQueue) {
-        [aView cancel];
+        [aView cancelAndRemove:NO];
     }
+    [_imageLoadingQueue removeAllObjects];
 }
 
 @end


### PR DESCRIPTION
Since we are accessing a static mutable array frequently, we need to make sure we are not mutating it either on enumeration or on evaluation. As a result, safeguard with cancel not being destructive on cancel all and wrap all access in NSLock.

Please evaluate.